### PR TITLE
Allow to customize Now() func in studyengine

### DIFF
--- a/pkg/studyengine/actions.go
+++ b/pkg/studyengine/actions.go
@@ -102,7 +102,7 @@ func updateLastSubmissionForSurvey(oldState ActionData, event types.StudyEvent) 
 	if newState.PState.LastSubmissions == nil {
 		newState.PState.LastSubmissions = map[string]int64{}
 	}
-	newState.PState.LastSubmissions[event.Response.Key] = time.Now().Unix()
+	newState.PState.LastSubmissions[event.Response.Key] = Now().Unix()
 	return
 }
 
@@ -612,7 +612,7 @@ func initReport(action types.Expression, oldState ActionData, event types.StudyE
 	newState.ReportsToCreate[reportKey] = types.Report{
 		Key:           reportKey,
 		ParticipantID: oldState.PState.ParticipantID,
-		Timestamp:     time.Now().Truncate(time.Minute).Unix(),
+		Timestamp:     Now().Truncate(time.Minute).Unix(),
 	}
 	return
 }
@@ -645,7 +645,7 @@ func updateReportData(action types.Expression, oldState ActionData, event types.
 		report = types.Report{
 			Key:           reportKey,
 			ParticipantID: oldState.PState.ParticipantID,
-			Timestamp:     time.Now().Truncate(time.Minute).Unix(),
+			Timestamp:     Now().Truncate(time.Minute).Unix(),
 		}
 	}
 

--- a/pkg/studyengine/expressions.go
+++ b/pkg/studyengine/expressions.go
@@ -1189,7 +1189,7 @@ func (ctx EvalContext) timestampWithOffset(exp types.Expression) (t float64, err
 	}
 	delta := int64(arg1.(float64))
 
-	referenceTime := time.Now().Unix()
+	referenceTime := Now().Unix()
 	if len(exp.Data) == 2 {
 		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
 		if err2 != nil {
@@ -1225,7 +1225,7 @@ func (ctx EvalContext) getTsForNextISOWeek(exp types.Expression) (t float64, err
 		return t, errors.New("argument 1 should be between 1 and 53")
 	}
 
-	referenceTime := time.Now()
+	referenceTime := Now()
 	if len(exp.Data) == 2 {
 		arg2, err2 := ctx.expressionArgResolver(exp.Data[1])
 		if err2 != nil {
@@ -1316,7 +1316,7 @@ func (ctx EvalContext) generateRandomNumber(exp types.Expression) (val float64, 
 	}
 	max := int(arg2.(float64))
 
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(Now().UnixNano())
 	randomVal := rand.Intn(max-min+1) + min
 	return float64(randomVal), nil
 }

--- a/pkg/studyengine/expressions.go
+++ b/pkg/studyengine/expressions.go
@@ -1316,7 +1316,7 @@ func (ctx EvalContext) generateRandomNumber(exp types.Expression) (val float64, 
 	}
 	max := int(arg2.(float64))
 
-	rand.Seed(Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 	randomVal := rand.Intn(max-min+1) + min
 	return float64(randomVal), nil
 }

--- a/pkg/studyengine/expressions_test.go
+++ b/pkg/studyengine/expressions_test.go
@@ -3219,3 +3219,53 @@ func TestEvalGetMessageNextTime(t *testing.T) {
 		}
 	})
 }
+
+func TestNow(t *testing.T) {
+	t.Run("testing now", func(t *testing.T) {
+		cur := time.Now()
+		now := Now()
+		if(cur.Sub(now).Abs() > time.Microsecond) {
+			t.Errorf("Current time is more than 1 microsecond")
+		}
+	})
+
+	t.Run("testing change time", func(t *testing.T) {
+		cur := time.Unix(1730419200, 0)
+		Now = func() time.Time {
+			return cur
+		}
+		now := Now()
+		if(cur.Sub(now).Abs() > 0) {
+			t.Errorf("Current time is not the time set %s got %s", cur, now)
+		}
+		Now = time.Now // resetting to current time
+	})
+
+	t.Run("testing change time on timestampWithOffset", func(t *testing.T) {
+		curTS := int64(1730419200)
+		cur := time.Unix(curTS, 0)
+		Now = func() time.Time {
+			return cur
+		}
+		exp := types.Expression{Name: "timestampWithOffset", Data: []types.ExpressionArg{
+				{DType: "num", Num: -10},
+			},
+		}
+		
+		EvalContext := EvalContext{
+			ParticipantState: types.ParticipantState{
+				StudyStatus: types.PARTICIPANT_STUDY_STATUS_ACTIVE,
+			},
+		}
+		ret, err := ExpressionEval(exp, EvalContext)
+		if err != nil {
+			t.Error(err)
+		} 
+		resTS := int64(ret.(float64))
+		expTS := curTS - 10
+		if( resTS != expTS) {
+			t.Errorf("Unexpected timestamp got %d, expecting %d", resTS, expTS)
+		}
+		Now = time.Now // resetting to current time
+	})
+}

--- a/pkg/studyengine/time.go
+++ b/pkg/studyengine/time.go
@@ -1,0 +1,8 @@
+package studyengine
+
+import(
+	"time"
+)
+
+// Now function control the current time used by the expressions. 
+var Now func() time.Time = time.Now


### PR DESCRIPTION
Introduce local Now() function instead of using directly time.Now() to be able to customize the current time used by the studyengine (for test for example)