### PR TITLE
add new environment variable to be able to disable timer task

### DIFF
--- a/cmd/study-service-app/main.go
+++ b/cmd/study-service-app/main.go
@@ -26,6 +26,8 @@ func main() {
 	if !conf.DisableTimerTask {
 		sTimerService := studytimer.NewStudyTimerService(conf.Study, studyDBService, globalDBService, conf.ExternalServices, conf.Study.GlobalSecret)
 		sTimerService.Run()
+	} else {
+		logger.Info.Println("Timer task disabled")
 	}
 
 	clients := &types.APIClients{}

--- a/cmd/study-service-app/main.go
+++ b/cmd/study-service-app/main.go
@@ -23,8 +23,10 @@ func main() {
 
 	ensureDBIndexes(globalDBService, studyDBService)
 
-	sTimerService := studytimer.NewStudyTimerService(conf.Study, studyDBService, globalDBService, conf.ExternalServices, conf.Study.GlobalSecret)
-	sTimerService.Run()
+	if !conf.DisableTimerTask {
+		sTimerService := studytimer.NewStudyTimerService(conf.Study, studyDBService, globalDBService, conf.ExternalServices, conf.Study.GlobalSecret)
+		sTimerService.Run()
+	}
 
 	clients := &types.APIClients{}
 

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -24,6 +24,7 @@ type Config struct {
 	}
 	PersistentStoreConfig types.PersistentStoreConfig
 	ExternalServices      []types.ExternalService
+	DisableTimerTask      bool
 }
 
 func InitConfig() Config {
@@ -47,6 +48,8 @@ func InitConfig() Config {
 	conf.PersistentStoreConfig = getPersistentStoreConfig()
 
 	conf.ExternalServices = getExternalServicesConfig()
+
+	conf.DisableTimerTask = os.Getenv("DISABLE_TIMER_TASK") == "true"
 	return conf
 }
 


### PR DESCRIPTION
This pull request introduces a new configuration option to control the execution of the study timer task. The most important changes include adding a new configuration field, updating the initialization function to set this field based on an environment variable, and modifying the main function to conditionally run the study timer service based on this new configuration.

### Configuration Changes:

* [`internal/config/configs.go`](diffhunk://#diff-34a0aab538a68f111bf5bb7b74e17c136c3f53aae86b3b9172cecfbfbc36fb1cR27): Added a new boolean field `DisableTimerTask` to the `Config` struct to allow enabling or disabling the study timer task.
* [`internal/config/configs.go`](diffhunk://#diff-34a0aab538a68f111bf5bb7b74e17c136c3f53aae86b3b9172cecfbfbc36fb1cR51-R52): Updated the `InitConfig` function to set the `DisableTimerTask` field based on the `DISABLE_TIMER_TASK` environment variable.

### Main Function Changes:

* [`cmd/study-service-app/main.go`](diffhunk://#diff-fc82fd0ef75af19608d1fae70026c1fa510b9344824c77676dbbffc626f16760R26-R29): Modified the `main` function to conditionally run the study timer service based on the `DisableTimerTask` configuration.