### PR TITLE
refactor: replace single choice response processing with group list handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.8.1] - 2025-01-14
+
+### Changed
+
+- exporter for responsive single choice array always using the list processing method (fix missing export, when only one row)
+
 ## [v1.8.0] - 2024-11-06
 
 ### Changed

--- a/pkg/exporter/response-utils.go
+++ b/pkg/exporter/response-utils.go
@@ -98,7 +98,7 @@ func getResponseColumns(question SurveyQuestion, response *types.SurveyItemRespo
 	case QUESTION_TYPE_LIKERT_GROUP:
 		return handleSingleChoiceGroupList(question.ID, question.Responses, response, questionOptionSep)
 	case QUESTION_TYPE_RESPONSIVE_SINGLE_CHOICE_ARRAY:
-		return processResponseForSingleChoice(question, response, questionOptionSep)
+		return handleSingleChoiceGroupList(question.ID, question.Responses, response, questionOptionSep)
 	case QUESTION_TYPE_RESPONSIVE_BIPOLAR_LIKERT_ARRAY:
 		return processResponseForSingleChoice(question, response, questionOptionSep)
 	case QUESTION_TYPE_MULTIPLE_CHOICE:


### PR DESCRIPTION
This pull request includes changes to the `CHANGELOG.md` and `pkg/exporter/response-utils.go` files to fix an issue with exporting responsive single choice arrays. The most important changes are:

* Updated the `CHANGELOG.md` to include a new version `v1.8.1` and a note about the change to the exporter for responsive single choice arrays.
* Modified the `getResponseColumns` function in `pkg/exporter/response-utils.go` to always use the `handleSingleChoiceGroupList` method for `QUESTION_TYPE_RESPONSIVE_SINGLE_CHOICE_ARRAY`, ensuring consistent export behavior.