### PR TITLE
Replace new lines in csv content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.8.2] - 2025-01-23
+
+### Changed
+
+- CSV exporter: replacing the `\r\n` and `\n` with `<br />` tags to avoid the line break in the exported CSV file (for support a wider range of CSV parser, that could not handle the `\r\n` and `\n` line breaks)
+
 ## [v1.8.1] - 2025-01-14
 
 ### Changed

--- a/pkg/exporter/response-utils.go
+++ b/pkg/exporter/response-utils.go
@@ -728,6 +728,12 @@ func responseColToString(responseCol interface{}) string {
 	return str
 }
 
+func replaceNewlines(str string) string {
+	newStr := strings.ReplaceAll(str, "\r\n", "<br />")
+	newStr = strings.ReplaceAll(newStr, "\n", "<br />")
+	return newStr
+}
+
 func isEmbeddedCloze(optionType string) bool {
 	return optionType == OPTION_TYPE_EMBEDDED_CLOZE_DATE_INPUT || optionType == OPTION_TYPE_EMBEDDED_CLOZE_DROPDOWN ||
 		optionType == OPTION_TYPE_EMBEDDED_CLOZE_NUMBER_INPUT || optionType == OPTION_TYPE_EMBEDDED_CLOZE_TEXT_INPUT

--- a/pkg/exporter/response_exporter.go
+++ b/pkg/exporter/response_exporter.go
@@ -401,7 +401,7 @@ func (rp ResponseExporter) GetResponsesCSV(writer io.Writer, includeMeta *Includ
 				line = append(line, "")
 				continue
 			}
-			line = append(line, responseColToString(v))
+			line = append(line, replaceNewlines(responseColToString(v)))
 		}
 
 		if includeMeta != nil {
@@ -508,7 +508,7 @@ func (rp ResponseExporter) GetResponsesLongFormatCSV(writer io.Writer, metaInfos
 			if !ok {
 				currentRespLine = append(currentRespLine, "")
 			} else {
-				currentRespLine = append(currentRespLine, responseColToString(v))
+				currentRespLine = append(currentRespLine, replaceNewlines(responseColToString(v)))
 			}
 
 			err := w.Write(currentRespLine)


### PR DESCRIPTION
This pull request includes changes to improve the handling of line breaks in the CSV exporter by replacing `\r\n` and `\n` with `<br />` tags. 

Changes to CSV export functionality:
* [`pkg/exporter/response-utils.go`](diffhunk://#diff-aa2d6cdda80f4c81ac15b74a9f5ed37db03cce9e0140f98f822cb1a71c5a64d1R731-R736): Added a new function `replaceNewlines` to replace `\r\n` and `\n` with `<br />` tags.
* [`pkg/exporter/response_exporter.go`](diffhunk://#diff-ab601f4acc08779b55dc4b16690a441dd666dac881479941b4c2a9530cc2644eL404-R404): Modified the `GetResponsesCSV` function to use the new `replaceNewlines` function when converting response columns to strings.
* [`pkg/exporter/response_exporter.go`](diffhunk://#diff-ab601f4acc08779b55dc4b16690a441dd666dac881479941b4c2a9530cc2644eL511-R511): Modified the `GetResponsesLongFormatCSV` function to use the new `replaceNewlines` function when converting response columns to strings.